### PR TITLE
android: add SUPPORTS_PTHREAD_GETNAME_NP definition

### DIFF
--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -235,3 +235,17 @@ struct mmsghdr {
   unsigned int msg_len;
 };
 #endif
+
+
+#define SUPPORTS_PTHREAD_GETNAME_NP
+#ifdef __linux__
+#undef SUPPORTS_PTHREAD_GETNAME_NP
+#endif
+
+// https://android.googlesource.com/platform/bionic/+/master/docs/status.md
+// pthread_getname_np is introduced in API 26
+#ifdef __ANDROID_API__
+#if __ANDROID_API__ < 26
+#undef SUPPORTS_PTHREAD_GETNAME_NP
+#endif // __ANDROID_API__ < 26
+#endif // ifdef __ANDROID_API__

--- a/source/common/common/posix/thread_impl.cc
+++ b/source/common/common/posix/thread_impl.cc
@@ -93,7 +93,7 @@ public:
   }
 
 private:
-#ifdef __linux__
+#ifdef SUPPORTS_PTHREAD_GETNAME_NP
   // Attempts to get the name from the operating system, returning true and
   // updating 'name' if successful. Note that during normal operation this
   // may fail, if the thread exits prior to the system call.


### PR DESCRIPTION
Mirroring the PR: https://github.com/envoyproxy/envoy/pull/11863

`pthread_getname_np` is introduced in [Android API 26](https://android.googlesource.com/platform/bionic/+/master/docs/status.md)


For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: android: add SUPPORTS_PTHREAD_GETNAME_NP definition
Additional Description:
Risk Level: low
Testing: ci
Docs Changes: n/a
Release Notes: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
